### PR TITLE
server: Use net.Conn interface in Process()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -147,9 +147,9 @@ func (s *session) dispatchCommand(cmd string, args []string,
 }
 
 // Process an NNTP session.
-func (s *Server) Process(tc *net.TCPConn) {
-	defer tc.Close()
-	c := textproto.NewConn(tc)
+func (s *Server) Process(nc net.Conn) {
+	defer nc.Close()
+	c := textproto.NewConn(nc)
 
 	sess := &session{
 		server:  s,


### PR DESCRIPTION
This allows implementations to pass a crypto/tls Conn, for instance.
